### PR TITLE
Update nom from 6.0 to 6.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "seeed-erpc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bbqueue",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ bitfield = "0.13"
 bitflags = "1.2"
 heapless = "0.8.0"
 bbqueue = "^0.4.11"
-nom = { version = "^6.0", default-features = false }
+nom = { version = "6.2.2", default-features = false }
 generic-array = { version = "0.14" }
 no-std-net = "0.5"


### PR DESCRIPTION
Here's a minor bump in nom, with this the wio_terminal examples can build without warnings!