### PR TITLE
Nom 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,12 +205,11 @@ checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
 
 [[package]]
 name = "nom"
-version = "6.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a7a9657c84d5814c6196b68bb4429df09c18b1573806259fba397ea4ad0d44"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bbqueue"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +87,35 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "generic-array"
@@ -68,6 +156,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,16 +214,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "seeed-erpc"
 version = "0.1.2"
 dependencies = [
  "bbqueue",
  "bitfield",
  "bitflags",
+ "env_logger",
  "generic-array 0.14.7",
  "heapless",
  "no-std-net",
  "nom",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -109,13 +310,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seeed-erpc"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Tom <twitchyliquid64@ciphersink.net>"]
 edition = "2018"
 description = "Driver crate for interacting with seeed-studio eRPC Wifi devices."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bitfield = "0.13"
 bitflags = "1.2"
 heapless = "0.8.0"
 bbqueue = "^0.4.11"
-nom = { version = "6.2.2", default-features = false }
+nom = { version = "8.0", default-features = false }
 generic-array = { version = "0.14" }
 no-std-net = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ bbqueue = "^0.4.11"
 nom = { version = "6.2.2", default-features = false }
 generic-array = { version = "0.14" }
 no-std-net = "0.5"
+
+[dev-dependencies]
+env_logger = "0.11.8"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,8 +1,5 @@
 use super::ids::*;
-use nom::{
-    error::ParseError, lib::std::ops::RangeFrom, number::streaming, IResult, InputIter,
-    InputLength, Slice,
-};
+use nom::{error::ParseError, number::streaming, IResult, Input};
 
 const BASIC_CODEC_VERSION: u8 = 1;
 
@@ -34,7 +31,7 @@ impl Header {
     /// Decodes an RPC header from a byte slice or other compatible type
     pub fn parse<I, E: ParseError<I>>(i: I) -> IResult<I, Self, E>
     where
-        I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+        I: Input<Item = u8>,
     {
         let (i, header) = streaming::le_u32(i)?;
         let (i, sequence) = streaming::le_u32(i)?;
@@ -76,7 +73,7 @@ impl FrameHeader {
     /// chained with other nom parsers.
     pub fn parse<I, E: ParseError<I>>(i: I) -> IResult<I, Self, E>
     where
-        I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+        I: Input<Item = u8>,
     {
         let (i, msg_length) = streaming::le_u16(i)?;
         let (i, crc16) = streaming::le_u16(i)?;
@@ -86,7 +83,7 @@ impl FrameHeader {
     /// Checks the CRC matches that computed from the provided payload.
     pub fn check_crc<I, E>(&self, data: I) -> Result<(), super::Err<E>>
     where
-        I: InputIter<Item = u8>,
+        I: Input<Item = u8>,
     {
         if crc16(data) == self.crc16 {
             Ok(())
@@ -99,7 +96,7 @@ impl FrameHeader {
 /// computes the CRC value used in the Wio Terminal eRPC codec
 pub(crate) fn crc16<I>(data: I) -> u16
 where
-    I: InputIter<Item = u8>,
+    I: Input<Item = u8>,
 {
     let mut crc: u32 = 0xEF4A;
 

--- a/src/system_rpcs.rs
+++ b/src/system_rpcs.rs
@@ -1,6 +1,6 @@
 use super::{codec, ids, Err};
 use heapless::String;
-use nom::{number::streaming, InputIter};
+use nom::{number::streaming, Input};
 
 /// Returns a string indicating the firmware version on the wifi chip.
 pub struct GetVersion {}

--- a/src/wifi_rpcs.rs
+++ b/src/wifi_rpcs.rs
@@ -417,3 +417,29 @@ impl super::RPC for WifiConnect {
         Ok(num)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RPC;
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn mac_address() {
+        init();
+        let mut input_bytes = [42u8; 36];
+
+        input_bytes[0] = 2; // MsgType::Reply
+        input_bytes[1] = 8; // WifiRequest::GetMacAddress
+        input_bytes[2] = 14; // Service::Wifi
+
+        input_bytes[8..30].copy_from_slice(b"01:23:45:67:89:01x\0\0\0\0");
+
+        let parsed = GetMacAddress {}.parse(&input_bytes).expect("Parse failed");
+
+        assert_eq!(parsed, "01:23:45:67:89:01");
+    }
+}

--- a/src/wifi_rpcs.rs
+++ b/src/wifi_rpcs.rs
@@ -2,10 +2,7 @@
 use super::{codec, ids, Err};
 use generic_array::{ArrayLength, GenericArray};
 use heapless::String;
-use nom::{
-    bytes::streaming::take, lib::std::ops::RangeFrom, lib::std::ops::RangeTo, number::streaming,
-    InputIter, InputLength, Slice,
-};
+use nom::{bytes::streaming::take, number::streaming, Input};
 
 /// Returns the mac address as a colon-separated hex string.
 pub struct GetMacAddress {}
@@ -36,11 +33,11 @@ impl super::RPC for GetMacAddress {
             return Err(Err::RPCErr(-1));
         }
         let mut mac: String<18> = String::new();
-        for b in data.slice(RangeTo { end: 17 }).iter_elements() {
+        for b in data.take(17).iter_elements() {
             mac.push(b as char).map_err(|_| Err::ResponseOverrun)?;
         }
 
-        let (_, result) = streaming::le_u32(data.slice(RangeFrom { start: 18 }))?;
+        let (_, result) = streaming::le_u32(data.take_from(18))?;
         if result != 0 {
             Err(Err::RPCErr(result as i32))
         } else {


### PR DESCRIPTION
We're now using a Cargo workspace for atsamd-rs, and one of the consequences is that the dependency graph now spans all the crates.  I'm working on adding a project management tool, and it has dependency requirements that clash with the old nom that seeed-erpc-rs brings in, updating nom sorts it out.